### PR TITLE
Update dns-settings.md

### DIFF
--- a/content/en/configuration/networking/dns-settings.md
+++ b/content/en/configuration/networking/dns-settings.md
@@ -55,7 +55,7 @@ The following table describes the DKIM records configuration settings per implem
 
 ### DNS records
 
-Note, the Autodiscover service external DNS entry is specific to the Hybrid implementation of the organisation. Once all mailboxes have been migrated to Office 365 within a Hybrid configuration this can be pointed as an alias to the Office 365 Autodiscover service using [autodiscover.outlook.com](autodiscover.outlook.com).
+Note, the Autodiscover service external DNS entry is specific to the Hybrid implementation of the organisation. Once all mailboxes have been migrated to Office 365 within a Hybrid configuration this can be pointed as an alias to the Office 365 Autodiscover service using autodiscover.outlook.com .
 
 Hybrid implementation types will require additional external DNS records depending on the hybrid implementation (classic or modern). The additional certificate requirements for hybrid can be located at - [certificate requirements for hybrid deployments](https://docs.microsoft.com/exchange/certificate-requirements).
 


### PR DESCRIPTION
The Autodiscover URL link was pointing to https://blueprint.asd.gov.au/configuration/networking/dns-settings/autodiscover.outlook.com which was invalid. As autodiscover.outlook.com is not an end user accessible site, i just remoted the link to the text all together.