### PR TITLE
Update journaling hyperlink so its clickable

### DIFF
--- a/content/en/design/shared-services/exchange-online/mailbox-auditing.md
+++ b/content/en/design/shared-services/exchange-online/mailbox-auditing.md
@@ -26,7 +26,7 @@ Within cloud native deployments, the option to capture all emails for Security O
 
 ### Hybrid deployments
 
-Journaling within hybrid deployments is accomplished using Exchange Journaling. See (/design/shared-services/exchange-online/journaling.md).
+Journaling within hybrid deployments is accomplished using Exchange Journaling. See [Journaling]({{<ref "/design/shared-services/exchange-online/journaling.md">}})	
 
 ### Mailbox Auditing configuration
 


### PR DESCRIPTION
Currently on the page at https://blueprint.asd.gov.au/design/shared-services/exchange-online/mailbox-auditing/ it renders like the picture below. This PR makes it render as a clickable link to the page. 

<img width="1109" height="200" alt="image" src="https://github.com/user-attachments/assets/d674c0b4-c30c-416e-a9f4-02b4063cb39f" />
